### PR TITLE
Add return document download button to shipping confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2020-02-19
+### Added
+- Add return document download button to shipping confirmation
+
 ## [1.1.0] - 2019-07-10
 ### Added
 - Add theme.xml file.

--- a/src/modules/toolbox.html
+++ b/src/modules/toolbox.html
@@ -55,6 +55,10 @@
 				before: '<button class="small-expand" href="',
 				after: '"><span>{%DownloadReceipt}</span></button>'
 			)}
+			{OrderReturnDocumentUrl(
+				before: '<button class="small-expand" href="',
+				after: '"><span>{%DownloadReturnDocument}</span></button>'
+			)}
 		{{/ifpage}}
 	</container>
 	<spacer size="30"></spacer>


### PR DESCRIPTION
## What has been done

Added return document download button to shipping confirmation toolbox module.

## Why

Because return documents can be downloaded only after the products have been shipped and for now the link has only been in the order confirmation return texts it hasn't been available in the shipping confirmation.