### PR TITLE
Fix product image size on mobile

### DIFF
--- a/src/assets/scss/modules/_order-contents.scss
+++ b/src/assets/scss/modules/_order-contents.scss
@@ -172,6 +172,7 @@ table.ProductsTotal {
 	.ProductRow .Image a img {
 		background: #ffffff !important;
 		border: 1px solid $color-image-border !important;
+		max-height: none !important;
 		padding: 4px !important;
 		width: 150px !important;
 	}


### PR DESCRIPTION
Removed max-height rule from product images that caused images to squish on mobile.