### PR TITLE
Add order cancellation request email template

### DIFF
--- a/src/pages/order/cancellation-request.html
+++ b/src/pages/order/cancellation-request.html
@@ -1,0 +1,62 @@
+---
+subject: '{OrderEmailTitle}'
+---
+
+{{> header }}
+
+<wrapper class="Primary">
+	<spacer size="10"></spacer>
+	<container class="Block">
+		<h1>{OrderEmailTitle}</h1>
+		<p>
+			{{> greeting }}
+			{%EmailTextOrderCancellationRequest}
+		</p>
+	</container>
+	<spacer size="20"></spacer>
+</wrapper>
+
+<wrapper class="Primary">
+	<container class="Block">
+		<row class="NoMargin">
+			<columns large="6">
+				<strong>{%EmailLabelOrderCancellationRequestReceivedAt}</strong><br />
+				{OrderCancellationRequestReceivedAt}
+			</columns>
+			<columns large="6">
+				<spacer size="10" class="Show-Small"></spacer>
+				<strong>{%EmailLabelOrderCancellationRequestSubmittedBy}</strong><br />
+				{OrderName}
+			</columns>
+		</row>
+		{OrderCancellationRequestReason(
+			before: '<row class="NoMargin"><columns><spacer size="10"></spacer><strong>{%EmailLabelOrderCancellationRequestReason}</strong><br />',
+			after: '</columns></row>'
+		)}
+	</container>
+	<spacer size="20"></spacer>
+</wrapper>
+
+<wrapper class="Secondary">
+	<spacer size="30"></spacer>
+	<container class="Block">
+		<h1>{%EmailLabelOrderCancellationRequestContents}</h1>
+		{OrderProducts(
+			before: '<hr />',
+			helper: 'emails/helpers/order-product'
+		)}
+		<spacer size="30"></spacer>
+	</container>
+	<spacer size="10"></spacer>
+</wrapper>
+
+<wrapper class="Primary">
+	<spacer size="10"></spacer>
+	<container class="Block">
+		<p>{%OrderCancellationProcessText}</p>
+	</container>
+	<spacer size="20"></spacer>
+</wrapper>
+
+{{> contact }}
+{{> footer }}

--- a/src/pages/order/cancellation-request.html
+++ b/src/pages/order/cancellation-request.html
@@ -7,7 +7,7 @@ subject: '{OrderEmailTitle}'
 <wrapper class="Primary">
 	<spacer size="10"></spacer>
 	<container class="Block">
-		<h1>{OrderEmailTitle}</h1>
+		<h1>{%EmailHeadingOrderCancellationRequest}</h1>
 		<p>
 			{{> greeting }}
 			{%EmailTextOrderCancellationRequest}
@@ -54,6 +54,7 @@ subject: '{OrderEmailTitle}'
 	<spacer size="10"></spacer>
 	<container class="Block">
 		<p>{%OrderCancellationProcessText}</p>
+		<p>{%EmailFooterOrderCancellationRequest}</p>
 	</container>
 	<spacer size="20"></spacer>
 </wrapper>


### PR DESCRIPTION
Inky source for the order cancellation request confirmation email (2018 email theme). Compiles to the `order/cancellation-request` template shown when a customer's cancellation request is received — order contents, receipt time, submitter, free-text reason, and an editable cancellation-process section.

The 2012-theme counterpart is in MyCashflow/MyCashflow-Default-Theme.